### PR TITLE
Changed index.php to posts.php in overloading-module-views.

### DIFF
--- a/content/general/theming/overloading-module-views.md
+++ b/content/general/theming/overloading-module-views.md
@@ -2,11 +2,11 @@
 
 PyroCMS is written intended to be styled mainly by CSS, but as designers you want full control over how your site looks. We understand that, so PyroCMS will let you replace any module view with a view inside your theme. Let&#39;s say you want to replace the main blog listing page. Simply copy:
 
-	system/cms/modules/blog/views/index.php
+	system/cms/modules/blog/views/posts.php
 
 to:
 
-	addons/<site-ref>/themes/<theme-name>/views/modules/blog/index.php
+	addons/<site-ref>/themes/<theme-name>/views/modules/blog/posts.php
 
 Now you can edit that view however you like and upgrade PyroCMS knowing your customized views are safe.</p>
 


### PR DESCRIPTION
Blog module was changed to use posts.php and index.php is no longer part of default install.
