### PR TITLE
Fixing a missing markdown title on general page.

### DIFF
--- a/content/general/index.md
+++ b/content/general/index.md
@@ -1,5 +1,6 @@
+# Welcome to PyroCMS
+
 <div class="intro">
-<h1>Welcome to PyroCMS</h1>
 <p class="flarge muted">If you are new to PyroCMS, we recommend starting with the Getting Started docs in order to get PyroCMS up and running, and then taking a look through the Basics to get the core concepts down.</p>
 </div>
 


### PR DESCRIPTION
The index.md under general does not have a markdown title and will not work with the new variable/title plugin. 
