### PR TITLE
Fixes some broken links and behavior

### DIFF
--- a/assets/embeds/header.html
+++ b/assets/embeds/header.html
@@ -60,7 +60,15 @@
 
 			<!-- doc_menu -->
 			<div id="doc_menu">
-				<h5>TABLE OF CONTENTS</h5>
+                                <h5>TABLE OF CONTENTS</h5>
+                                {{ if !segment_1 }}
+                                    <ul>
+					<li{{ if segment_1 == 'general' }} class="current"{{ endif }}>{{ link uri="general" title="General Info" }}</li>
+					<li{{ if segment_1 == 'modules-and-tags' }} class="current"{{ endif }}>{{ link uri="modules-and-tags" title="Modules &amp; Tags" }}</li>
+					<li{{ if segment_1 == 'developers' }} class="current"{{ endif }}>{{ link uri="developers" title="Developers" }}</li>
+					<li{{ if segment_1 == 'pyrocms-pro' }} class="current"{{ endif }}>{{ link uri="pyrocms-pro" title="PyroCMS Pro" }}</li>
+				</ul>
+                                {{ endif }}
 				{{ if segment_1 == 'general' }}
 					<strong>About PyroCMS</strong>
 					{{ nav:auto start='general/about' }}

--- a/content/developers/contributing/store-submission-guidelines.md
+++ b/content/developers/contributing/store-submission-guidelines.md
@@ -1,0 +1,27 @@
+# Store Submission Guidelines
+
+When you create a add-on that is useful to other people you can share it on the [Add-on Store](http://www.pyrocms.com/store). When a add-on is submitted it will be validated by the development team to make sure it is up to scratch. This process is not as tough as getting an iPhone App into the App Store, but we will give it a run through to make sure it is working properly and not doing anything it shouldn't. If it sells the developer will receive 70% of the proceeds (distributed monthly). The other 30% goes towards paying the store operating costs and to fund additional development.
+
+To make sure your add-on is accepted quickly, please follow the following guidelines.
+
+## All Add-ons
+
+* Must be version 1.0 or greater
+* Description should clearly state what the add-on does
+* Listing must have at least one screenshot
+* Live previews are recommended but not required
+* Must include documentation or specify where the documentation is found
+* Specify any dependencies (for example: This widget requires a theme with jQuery)
+
+## Additional Guidelines
+### Themes
+
+* Should specify which major browsers it has been tested with
+* The downloadable zip must upload and install without errors via PyroCMS' admin panel.
+* A live preview is required
+
+### Modules
+
+* The downloadable zip must upload and install without errors via PyroCMS' admin panel.
+
+All good? Go to the [Add-on Submission](http://www.pyrocms.com/store/add/details) page and fill out all of the relevant details.

--- a/content/general/basics/pyrocms-tags.md
+++ b/content/general/basics/pyrocms-tags.md
@@ -4,12 +4,10 @@ One of the unique features of PyroCMS is Tags, powered by the [Lex Parser](https
 
 The following guide will teach you the basics of tags and how to use them in your layouts.
 
-<ul id="doc_sub_nav">
-<li><a href="#basic">Basic Tags</a></li>
-<li><a href="#attributes">Tag Attributes</a></li>
-<li><a href="#pairs">Tag Pairs</a></li>
-<li><a href="#conditionals">Tag Conditionals</a></li>
-</ul>
+* {{ link uri="/general/basics/pyrocms-tags/#basic" title="Basic Tags" }}
+* {{ link uri="/general/basics/pyrocms-tags/#attributes" title="Tag Attributes" }}
+* {{ link uri="/general/basics/pyrocms-tags/#pairs" title="Tag Pairs" }}
+* {{ link uri="/general/basics/pyrocms-tags/#conditionals" title="Tag Conditionals" }}
 
 <div id="basic"></div>
 

--- a/content/index.md
+++ b/content/index.md
@@ -4,22 +4,20 @@
 <p class="flarge muted">If you are new to PyroCMS, we recommend starting with the Getting Started docs in order to get PyroCMS up and running, and then taking a look through the Basics to get the core concepts down.</p>
 </div>
 
-<div class="one_half">
 <h3>General Info</h3>
 <p class="flarge muted">In the {{ link uri="general" title="General Info" }} section, you can find documentation on installing and using PyroCMS, including using and building themes.</p>
-</div>
 
-<div class="one_half">
+<hr>
+
 <h3>Modules &amp; Tags</h3>
 <p class="flarge muted">In the {{ link uri="modules-and-tags" title="Modules &amp; Tags" }} section, you can find reference of tag functions, as well as documentation for modules.</p>
-</div>
 
-<div class="one_half">
+<hr>
+
 <h3>Developers</h3>
 <p class="flarge muted">In the {{ link uri="developers" title="Developers" }} section, you can find documentation for developing PyroCMS addons, as well as a guide to contributing to PyroCMS.</p>
-</div>
 
-<div class="one_half last">
+<hr>
+
 <h3>PyroCMS Pro</h3>
 <p class="flarge muted">In the {{ link uri="pyrocms-pro" title="PyroCMS Pro" }} section, you can find documentation specifically for the Pro version of PyroCMS.</p>
-</div>


### PR DESCRIPTION
This will fix the following:
- links at the top of general>basics>pryocms-tags 
- ports the store submission guidelines from 1.3 to 2.1 docs to fix a 404
- repeats the top nav in table of contents on the index page so that TOC is not just blank. 
