### PR TITLE
Widget locations were incorrect

### DIFF
--- a/content/developers/addons/developing-widgets.md
+++ b/content/developers/addons/developing-widgets.md
@@ -6,9 +6,10 @@ Widgets are quite similar to <a href="/docs/glossary#plugins">Plugins</a> in the
 
 ##Where do i put my widgets?
 
-Widgets can be stored directly in two places
+Widgets can be stored directly in three places
 
-* the /addons/shared_addons/widgets/*&lt;widget-name&gt;* folder 
+* the /addons/&lt;site-ref&gt;/widgets/*&lt;widget-name&gt;* folder
+* or the /addons/shared_addons/widgets/*&lt;widget-name&gt;* folder
 * or inside a module folder for example: /addons/modules/*&lt;module-name&gt;/widgets/&lt;widget-name&gt;*
 
 ## What are the main components of a widget

--- a/content/developers/addons/developing-widgets.md
+++ b/content/developers/addons/developing-widgets.md
@@ -6,10 +6,9 @@ Widgets are quite similar to <a href="/docs/glossary#plugins">Plugins</a> in the
 
 ##Where do i put my widgets?
 
-Widgets can be stored directly in three places
+Widgets can be stored directly in two places
 
-* the /addons/widgets folder 
-* the /addons/widgets/*&lt;widget-name&gt;* 
+* the /addons/shared_addons/widgets/*&lt;widget-name&gt;* folder 
 * or inside a module folder for example: /addons/modules/*&lt;module-name&gt;/widgets/&lt;widget-name&gt;*
 
 ## What are the main components of a widget
@@ -90,7 +89,7 @@ Please take this opportunity to read through the code below and make note of the
 	     * data returned from this method will be available to views/form.php
 	     */
 	    public function form()
-	    { 
+	    {
 	        $stuff = $this->db->get_stuff();
             return array('stuff' => $stuff);
 	    }
@@ -98,7 +97,7 @@ Please take this opportunity to read through the code below and make note of the
 
 If you have made it this far and have read the comments in the above code that should pretty much get you on the right path to creating your first widget. However I would like to point out one thing before moving on.
 
-The widget class name should be in the following format: "**Widget_Awesome_sauce**" and must extend the "**Widgets**" core class.
+The widget class name should be in the following format: "**Widget\_Awesome\_sauce**" and must extend the "**Widgets**" core class.
 
 ### The view files
 

--- a/content/modules-and-tags/tag-reference/theme.md
+++ b/content/modules-and-tags/tag-reference/theme.md
@@ -33,13 +33,13 @@ Displays an option for the current theme. To read more about this tag and its us
 **Example:**
 
 	{{ noparse }}&#123;&#123; if theme:options:layout == 'full-width' &#125;&#125;{{ /noparse }}
-			
+
 		{{ noparse }}&lt;div class="full-width"&gt;{{ /noparse }}
-				
+
 			{{ noparse }}{{ template:body }}{{ /noparse }}
-			
+
 		{{ noparse }}&lt;/div&gt;{{ /noparse }}
-		
+
 	{{ noparse }}{{ endif }}{{ /noparse }}
 
 #### {{ noparse }} {{ theme:partial }} {{ /noparse }} ####
@@ -105,13 +105,19 @@ Generates a &lt;link&gt; to a css file in the current theme.
 			<td width="100">No</td>
 			<td>The media attribute.</td>
 		</tr>
+        <tr>
+            <td width="100">rel</td>
+            <td width="100">stylesheet</td>
+            <td width="100">No</td>
+            <td>The rel attribute.</td>
+        </tr>
 	</tbody>
 </table>
 
 **Example:**
-	
+
 	{{ noparse }}&#123;&#123; theme:css file="style.css" &#125;&#125;{{ /noparse }}
-	
+
 	{{ noparse }}&lt;link href="themes/default/css/style.css" type="text/css" rel="stylesheet" /&gt;{{ /noparse }}
 
 #### {{ noparse }}{{ theme:image }}{{ /noparse }} ####
@@ -143,7 +149,7 @@ Generates an &lt;img&gt; tag for an file in the current theme.
 </table>
 
 **Example:**
-	
+
 	{{ noparse }}&#123;&#123; theme:image file="fun.jpg" alt="Fun!" &#125;&#125;{{ /noparse }}
 
 	{{ noparse }}&lt;img href="themes/default/img/fun.jpg" alt="Fun!" /&gt;{{ /noparse }}
@@ -171,9 +177,9 @@ Generates a &lt;js&gt; script link for a javascript file in the current theme.
 </table>
 
 **Example:**
-	
+
 	{{ noparse }}&#123;&#123; theme:js file="extra.js" &#125;&#125;{{ /noparse }}
-	
+
 	{{ noparse }}&lt;script type="text/javascript" src="themes/default/js/extra.js"&gt;{{ /noparse }}
 
 #### {{ noparse}}{{ theme:favicon }}{{ /noparse }} ####
@@ -223,7 +229,7 @@ Generates a &lt;link&gt; tag for a favicon file in the current theme.
 </table>
 
 **Example:**
-	
+
 	{{ noparse }}&#123;&#123; theme:favicon file="favicon.png" &#125;&#125;{{ /noparse }}
 
 	{{ noparse }}&lt;link href="/system/pyrocms/themes/default/img/favicon.png" rel="shortcut icon" type="imagem/x-icon"&gt;{{ /noparse }}


### PR DESCRIPTION
While developing a widget, they should be in the "shared_addons" folder, otherwise they won't show up in the widget instance list. I realise it said there were three locations, but the top two were the same?

If the third location is known, obviously just change the "two" to "three".

Also, slight formatting error with the class displaying no underscores.
