### PR TITLE
Typo in allowed functions for helper: character_limiter

### DIFF
--- a/content/modules-and-tags/tag-reference/helper.md
+++ b/content/modules-and-tags/tag-reference/helper.md
@@ -289,7 +289,7 @@ The functions that can be used are defined in system/cms/config/parser.php
 
 This is the current list:
 
- * character\_limit
+ * character\_limiter
  * count
  * count\_chars
  * empty


### PR DESCRIPTION
https://www.pyrocms.com/forums/topics/view/21098 and 
https://github.com/pyrocms/pyrocms/pull/1913

(Will you merge this with 2.2 & restructure?)
