### PR TITLE
Added Helpers documentation for all helpers

### DIFF
--- a/content/developers/tools/helpers/admin-theme-helper.md
+++ b/content/developers/tools/helpers/admin-theme-helper.md
@@ -1,0 +1,61 @@
+# Admin Theme Helper
+
+This helper is intended to be used with your Admin Theme.
+
+## Functions
+
+
+### file_partial($file = '', $ext = 'php')
+
+Loads a file partial from your Theme Views Partials folder. `echo`'s directly to the page.
+
+<table cellpadding="0" cellspacing="0">
+	<tbody>
+		<tr>
+			<th width="100">Name</th>
+			<th width="100">Default</th>
+			<th width="100">Required</th>
+			<th>Description</th>
+		</tr>
+		<tr>
+			<td>file</td>
+			<td></td>
+			<td>Yes</td>
+			<td>The path to the view. Inside <dfn>THEME_VIEWS_FOLDER/partials/</dfn></td>
+		</tr>
+		<tr>
+			<td>ext</td>
+			<td>php</td>
+			<td>No</td>
+			<td>Extension of the file of other than <em>php</em></td>
+		</tr>
+	</tbody>
+</table>
+
+
+### template_partial($name = '')
+
+Loads a template partial previously set with `$this->template->partial()`. `echo`'s directly to the page.
+
+<table cellpadding="0" cellspacing="0">
+	<tbody>
+		<tr>
+			<th width="100">Name</th>
+			<th width="100">Default</th>
+			<th width="100">Required</th>
+			<th>Description</th>
+		</tr>
+		<tr>
+			<td>name</td>
+			<td></td>
+			<td>Yes</td>
+			<td>The name you set the partial as</td>
+		</tr>
+	</tbody>
+</table>
+
+{{# Internal only?
+### accented_characters()
+
+Returns the array of the accented characters and their replacements set in <dfn>config/foreign_chars.php</dfn>.
+#}}

--- a/content/developers/tools/helpers/array-helper.md
+++ b/content/developers/tools/helpers/array-helper.md
@@ -1,0 +1,241 @@
+# Array Helper
+
+This helper adds functionality not available in the [CodeIgniter Array Helper](http://codeigniter.com/user_guide/helpers/array_helper.html).
+
+## Functions
+
+
+### array\_object\_merge(&$object, $array)
+
+Merge an array or an object into another object. Returns the merged object.
+
+<table cellpadding="0" cellspacing="0">
+	<tbody>
+		<tr>
+			<th width="100">Name</th>
+			<th width="100">Default</th>
+			<th width="100">Required</th>
+			<th>Description</th>
+		</tr>
+		<tr>
+			<td>object</td>
+			<td></td>
+			<td>Yes</td>
+			<td>The Object to merge into. Passed by reference.</td>
+		</tr>
+		<tr>
+			<td>array</td>
+			<td></td>
+			<td>Yes</td>
+			<td>The Array or Object to merge</td>
+		</tr>
+	</tbody>
+</table>
+
+### array\_for\_select(args)
+
+Reformat an array to be ready for the HTML Select helper or other shenanigans.
+
+This function can behave in different ways based on how you pass in your arguments. Please refer to one of the following formats:
+
+#### array\_for\_select($array, $keys\_key, $values\_key)
+
+This is the most common usage and will reformat your array so that the <var>$keys\_key</var> will be the new array keys and the <var>$values\_key</var> will be the new values. See code example below.
+
+<table cellpadding="0" cellspacing="0">
+	<tbody>
+		<tr>
+			<th width="100">Name</th>
+			<th width="100">Default</th>
+			<th width="100">Required</th>
+			<th>Description</th>
+		</tr>
+		<tr>
+			<td>array</td>
+			<td></td>
+			<td>Yes</td>
+			<td>The Array of data. See format below.</td>
+		</tr>
+		<tr>
+			<td>keys_key</td>
+			<td></td>
+			<td>Yes</td>
+			<td>The <em>key</em> to the new keys value</td>
+		</tr>
+		<tr>
+			<td>values_key</td>
+			<td></td>
+			<td>Yes</td>
+			<td>The <em>key</em> to the new values value</td>
+		</tr>
+	</tbody>
+</table>
+
+	// input array
+	$array = array(
+		array('id' => 1, 'title' => 'One'),
+		array('id' => 2, 'title' => 'Two'),
+		array('id' => 3, 'title' => 'Three')
+	);
+	
+	// usage
+	$result = array_for_select($array, 'id', 'title');
+	
+	// $result
+	Array
+	(
+		[1] => One
+		[2] => Two
+		[3] => Three
+	);
+
+
+#### array\_for\_select($array, $values\_key)
+
+This is used when you have key / value pairs and want to preserve the keys. This will reformat your array so that the <var>$array</var>'s key will be the new array keys and the <var>$values\_key</var> will be the new values. See code example below.
+
+<table cellpadding="0" cellspacing="0">
+	<tbody>
+		<tr>
+			<th width="100">Name</th>
+			<th width="100">Default</th>
+			<th width="100">Required</th>
+			<th>Description</th>
+		</tr>
+		<tr>
+			<td>array</td>
+			<td></td>
+			<td>Yes</td>
+			<td>The Array of data. See format below.</td>
+		</tr>
+		<tr>
+			<td>values_key</td>
+			<td></td>
+			<td>Yes</td>
+			<td>The <em>key</em> to the new values value</td>
+		</tr>
+	</tbody>
+</table>
+
+	// input array
+	$array = array(
+		'item_1' => array('id' => 1, 'title' => 'One'),
+		'item_2' => array('id' => 2, 'title' => 'Two'),
+		'item_3' => array('id' => 3, 'title' => 'Three')
+	);
+	
+	// usage
+	$result = array_for_select($array, 'title');
+	
+	// $result
+	Array
+	(
+		[item_1] => One
+		[item_2] => Two
+		[item_3] => Three
+	);
+
+
+#### array\_for\_select($array)
+
+This is used when you have a collection of values that need the same keys and values. This will reformat your array so that the <var>$array</var>'s key will be the new array key and value. See code example below.
+
+<table cellpadding="0" cellspacing="0">
+	<tbody>
+		<tr>
+			<th width="100">Name</th>
+			<th width="100">Default</th>
+			<th width="100">Required</th>
+			<th>Description</th>
+		</tr>
+		<tr>
+			<td>array</td>
+			<td></td>
+			<td>Yes</td>
+			<td>The Array of data. See format below.</td>
+		</tr>
+	</tbody>
+</table>
+
+	// input array
+	$array = array(
+		'One',
+		'Two',
+		'Three'
+	);
+	
+	// usage
+	$result = array_for_select($array);
+	
+	// $result
+	Array
+	(
+		[One] => One
+		[Two] => Two
+		[Three] => Three
+	);
+
+
+
+### assoc\_array\_prop(array &$arr = null, $prop = 'id')
+
+Reformat an array so the keys are `$prop`'s value and preserve each items data.
+
+<table cellpadding="0" cellspacing="0">
+	<tbody>
+		<tr>
+			<th width="100">Name</th>
+			<th width="100">Default</th>
+			<th width="100">Required</th>
+			<th>Description</th>
+		</tr>
+		<tr>
+			<td>array</td>
+			<td></td>
+			<td>Yes</td>
+			<td>The Array of data. Assigned by reference.</td>
+		</tr>
+		<tr>
+			<td>prop</td>
+			<td>id</td>
+			<td>No</td>
+			<td>The <em>key</em> to the new keys value</td>
+		</tr>
+	</tbody>
+</table>
+
+	// data
+	$array = array(
+		array('id' => 1, 'title' => 'One', 'order' => 2),
+		array('id' => 3, 'title' => 'Three', 'order' => 1),
+		array('id' => 4, 'title' => 'Four', 'order' => 3)
+	);
+	
+	// reformat
+	assoc_array_prop($array, 'id');
+	
+	// result
+	Array
+	(
+		[1] => Array
+			(
+				[id] => 1
+				[title] => One
+				[order] => 2
+			)
+	
+		[3] => Array
+			(
+				[id] => 3
+				[title] => Three
+				[order] => 1
+			)
+	
+		[4] => Array
+			(
+				[id] => 4
+				[title] => Four
+				[order] => 3
+			)
+
+	)

--- a/content/developers/tools/helpers/comments-helper.md
+++ b/content/developers/tools/helpers/comments-helper.md
@@ -1,0 +1,70 @@
+# Comments Helper
+
+A collection of helper functions included with the Comments module.
+
+## Functions
+
+
+### display\_comments($module\_item\_id = '', $module\_slug = null)
+
+Display the comments on a specific item and show the add a comment form.
+
+<table cellpadding="0" cellspacing="0">
+	<tbody>
+		<tr>
+			<th width="100">Name</th>
+			<th width="100">Default</th>
+			<th width="100">Required</th>
+			<th>Description</th>
+		</tr>
+		<tr>
+			<td>module_item_id</td>
+			<td></td>
+			<td>Yes</td>
+			<td>Unique ID of the module item</td>
+		</tr>
+		<tr>
+			<td>module_slug</td>
+			<td>(Current Module)</td>
+			<td>No</td>
+			<td>Module slug of module to look in</td>
+		</tr>
+	</tbody>
+</table>
+
+	// shows the comment form along with any comments
+	// on the blog post with the id of 5
+	display_comments(5, 'blog');
+
+### count\_comments($module\_item\_id = '', $module\_slug = null, $return\_as\_number = false)
+
+Count the number of comments a specific item has. This is used when determining the language used for singular vs. plural of comments.
+
+<table cellpadding="0" cellspacing="0">
+	<tbody>
+		<tr>
+			<th width="100">Name</th>
+			<th width="100">Default</th>
+			<th width="100">Required</th>
+			<th>Description</th>
+		</tr>
+		<tr>
+			<td>module_item_id</td>
+			<td></td>
+			<td>Yes</td>
+			<td>Unique ID of the module item</td>
+		</tr>
+		<tr>
+			<td>module_slug</td>
+			<td>(Current Module Slug)</td>
+			<td>No</td>
+			<td>Module slug of module to look in</td>
+		</tr>
+		<tr>
+			<td>return_as_number</td>
+			<td>false</td>
+			<td>No</td>
+			<td>Return the actual number of comments, or lookup in lang: <em>comments.counter_none_label, comments.counter_singular_label, comments.counter_plural_label</em></td>
+		</tr>
+	</tbody>
+</table>

--- a/content/developers/tools/helpers/date-helper.md
+++ b/content/developers/tools/helpers/date-helper.md
@@ -1,0 +1,33 @@
+# Date Helper
+
+This helper adds functionality not available in the [CodeIgniter Date Helper](http://codeigniter.com/user_guide/helpers/date_helper.html).
+
+## Functions
+
+
+### format_date($unix, $format = '')
+
+Format a UNIX Timestamp to a specific format or use the default date format in the site settings.
+
+<table cellpadding="0" cellspacing="0">
+	<tbody>
+		<tr>
+			<th width="100">Name</th>
+			<th width="100">Default</th>
+			<th width="100">Required</th>
+			<th>Description</th>
+		</tr>
+		<tr>
+			<td>unix</td>
+			<td></td>
+			<td>Yes</td>
+			<td>A UNIX Timestamp or <code>strtotime()</code> valid string</td>
+		</tr>
+		<tr>
+			<td>format</td>
+			<td>(Site Settings Date Format)</td>
+			<td>No</td>
+			<td>The PHP Date format for the date</td>
+		</tr>
+	</tbody>
+</table>

--- a/content/developers/tools/helpers/debug-helper.md
+++ b/content/developers/tools/helpers/debug-helper.md
@@ -1,0 +1,24 @@
+# Debug Helper
+
+A simple debugging helper for use while developing.
+
+## Functions
+
+
+### dump(args)
+
+Do a `var_dump()` along with a bounding box and file info.
+
+#### Example Output
+
+<fieldset style="background: #fefefe !important; border:2px red solid; padding:5px"><legend style="background:lightgrey; padding:5px;">/path/to/file.php @ line: 42</legend><pre><br/><strong>Debug #1 of 1</strong>: array(4) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  bool(true)
+  [3]=>
+  string(6) "Orange"
+}
+</pre></fieldset>

--- a/content/developers/tools/helpers/gravatar-helper.md
+++ b/content/developers/tools/helpers/gravatar-helper.md
@@ -1,0 +1,51 @@
+# Gravatar Helper
+
+Helper functions to interact with Gravatar.
+
+## Functions
+
+
+### gravatar($email = '', $size = 50, $rating = 'g', $url_only = false, $default = false)
+
+Get a Gravatar image based on the passed in params.
+
+<table cellpadding="0" cellspacing="0">
+	<tbody>
+		<tr>
+			<th width="100">Name</th>
+			<th width="100">Default</th>
+			<th width="100">Required</th>
+			<th>Description</th>
+		</tr>
+		<tr>
+			<td>email</td>
+			<td></td>
+			<td>Yes</td>
+			<td>E-mail address of the Gravatar user</td>
+		</tr>
+		<tr>
+			<td>size</td>
+			<td>50</td>
+			<td>No</td>
+			<td>The size of the image in <em>px</em></td>
+		</tr>
+		<tr>
+			<td>rating</td>
+			<td>g</td>
+			<td>No</td>
+			<td>Limit the image to a specific rating</td>
+		</tr>
+		<tr>
+			<td>url_only</td>
+			<td>false</td>
+			<td>No</td>
+			<td>Return only the URL to the image file? Otherwise, returns <code>&lt;img /&gt;</code> tag.</td>
+		</tr>
+		<tr>
+			<td>default</td>
+			<td>false</td>
+			<td>No</td>
+			<td>URL to an image to use as the default if no Gravatar available</td>
+		</tr>
+	</tbody>
+</table>

--- a/content/developers/tools/helpers/html-helper.md
+++ b/content/developers/tools/helpers/html-helper.md
@@ -1,0 +1,92 @@
+# HTML Helper
+
+This helper adds functionality not available in the [CodeIgniter HTML Helper](http://codeigniter.com/user_guide/helpers/html_helper.html).
+
+## Functions
+
+
+### tree_builder($items, $html)
+
+Helps build the HTML for a UI Tree element.
+
+<div class="tip"><strong>Note:</strong> This function only created the HTML for the UI Tree element. You will still need to include the script on your own. This may or may not be done for you in the admin theme.</div>
+
+<table cellpadding="0" cellspacing="0">
+	<tbody>
+		<tr>
+			<th width="100">Name</th>
+			<th width="100">Default</th>
+			<th width="100">Required</th>
+			<th>Description</th>
+		</tr>
+		<tr>
+			<td>items</td>
+			<td></td>
+			<td>Yes</td>
+			<td>An array of items that may or may not have children (under a key named <code>children</code> for each appropriate array entry). See example format below.</td>
+		</tr>
+		<tr>
+			<td>html</td>
+			<td></td>
+			<td>Yes</td>
+			<td>The HTML string to parse. See example below.</td>
+		</tr>
+	</tbody>
+</table>
+
+#### Example
+
+This is taken from the Pages module which has the UI Tree for sorting pages.
+
+	// example format of $items array
+	Array
+	(
+	    [0] => Array
+	        (
+	            [id] => 1
+	            [parent_id] => 0
+	            [title] => Home
+	        )
+	
+	    [1] => Array
+	        (
+	            [id] => 2
+	            [parent_id] => 0
+	            [title] => Page missing
+	        )
+	
+	    [2] => Array
+	        (
+	            [id] => 2
+	            [parent_id] => 0
+	            [title] => Contact Us
+	        )
+	
+	    [3] => Array
+	        (
+	            [id] => 3
+	            [parent_id] => 0
+	            [title] => Search
+	            [children] => Array
+	                (
+	                    [0] => Array
+	                        (
+	                            [id] => 4
+	                            [parent_id] => 3
+	                            [title] => Results
+	                        )
+	                        												
+	                    [1] => Array
+	                        (
+	                            [id] => 5
+	                            [parent_id] => 3
+	                            [title] => No Results
+	                        )
+	
+	                )
+	
+	        )
+	)
+	
+	// example format of $html string
+	{{noparse}}<li id="{{ id }}"><a href="#">{{ title }}</a>{{ children }}</li>{{/noparse}}

--- a/content/developers/tools/helpers/index.md
+++ b/content/developers/tools/helpers/index.md
@@ -1,0 +1,5 @@
+# Helpers
+
+PyroCMS has some additional and modified helpers on top of the stock [CodeIgniter Helpers](http://codeigniter.com/user_guide/general/helpers.html) to make developing with PyroCMS a little easier. Make sure to get familiar with these since they might save you time later on:
+
+{{ nav:auto start="developers/tools/helpers" }}

--- a/content/developers/tools/helpers/inflector-helper.md
+++ b/content/developers/tools/helpers/inflector-helper.md
@@ -1,0 +1,62 @@
+# Inflector Helper
+
+This helper adds functionality not available in the [CodeIgniter Inflector Helper](http://codeigniter.com/user_guide/helpers/inflector_helper.html).
+
+## Functions
+
+
+### humanize($str)
+
+__&#42;&#42;Overrides default CodeIgniter function.&#42;&#42;__
+
+Takes multiple words separated by underscores and changes them to spaces.
+
+<table cellpadding="0" cellspacing="0">
+	<tbody>
+		<tr>
+			<th width="100">Name</th>
+			<th width="100">Default</th>
+			<th width="100">Required</th>
+			<th>Description</th>
+		</tr>
+		<tr>
+			<td>str</td>
+			<td></td>
+			<td>Yes</td>
+			<td>A string to <em>humanize</em>.</td>
+		</tr>
+	</tbody>
+</table>
+
+	// usage
+	humanize('what_would_you_like_to_do_today');
+	
+	// output
+	'What Would You Like To Do Today'
+
+### keywords($str)
+
+Takes multiple words separated by spaces and changes them to _keywords_ in the PyroCMS context. Makes sure the keywords are separated by a comma followed by a space.
+
+<table cellpadding="0" cellspacing="0">
+	<tbody>
+		<tr>
+			<th width="100">Name</th>
+			<th width="100">Default</th>
+			<th width="100">Required</th>
+			<th>Description</th>
+		</tr>
+		<tr>
+			<td>str</td>
+			<td></td>
+			<td>Yes</td>
+			<td>Keywords separated by spaces: <em>Ex: 'keyword_1 keyword_2 keyword_3'</em></td>
+		</tr>
+	</tbody>
+</table>
+
+	// usage
+	keywords('keyword_1 keyword_2 keyword_3');
+	
+	// output
+	'keyword_1, keyword_2, keyword_3'

--- a/content/developers/tools/helpers/markdown-helper.md
+++ b/content/developers/tools/helpers/markdown-helper.md
@@ -1,0 +1,33 @@
+# Markdown Helper
+
+Some Markdown helper functions to interact with the [Markdown syntax](http://daringfireball.net/projects/markdown/). We use the [PHP Markdown](http://michelf.com/projects/php-markdown/) version of Markdown.
+
+## Functions
+
+
+### parse_markdown($markdown)
+
+Parse a block of markdown and get HTML back.
+
+<table cellpadding="0" cellspacing="0">
+	<tbody>
+		<tr>
+			<th width="100">Name</th>
+			<th width="100">Default</th>
+			<th width="100">Required</th>
+			<th>Description</th>
+		</tr>
+		<tr>
+			<td>markdown</td>
+			<td></td>
+			<td>Yes</td>
+			<td>A <strong>Markdown</strong> formatted string</td>
+		</tr>
+	</tbody>
+</table>
+
+	// usage
+	parse_markdown("Let's convert this _text_ to **Markdown**.");
+	
+	// output
+	"<p>Let's convert this <em>text</em> to <strong>Markdown</strong>.</p>"

--- a/content/developers/tools/helpers/module-helper.md
+++ b/content/developers/tools/helpers/module-helper.md
@@ -1,0 +1,87 @@
+# Module Helper
+
+A collection of helper functions included with the Modules module.
+
+## Functions
+
+
+### module_directories()
+
+Returns an array of the module directories.
+
+
+### module_array()
+
+Returns an array of the modules and their information.
+
+
+### module_exists($module = '')
+
+Check if a module exists. Returns bool.
+
+<table cellpadding="0" cellspacing="0">
+	<tbody>
+		<tr>
+			<th width="100">Name</th>
+			<th width="100">Default</th>
+			<th width="100">Required</th>
+			<th>Description</th>
+		</tr>
+		<tr>
+			<td>module</td>
+			<td></td>
+			<td>Yes</td>
+			<td>Module slug</td>
+		</tr>
+	</tbody>
+</table>
+
+{{# I don't believe this method works correctly
+### module_controller($controller, $module)
+
+Check if the module has a controller with the name given. Returns bool.
+
+<table cellpadding="0" cellspacing="0">
+	<tbody>
+		<tr>
+			<th width="100">Name</th>
+			<th width="100">Default</th>
+			<th width="100">Required</th>
+			<th>Description</th>
+		</tr>
+		<tr>
+			<td>controller</td>
+			<td></td>
+			<td>Yes</td>
+			<td>Controller name</td>
+		</tr>
+		<tr>
+			<td>module</td>
+			<td></td>
+			<td>Yes</td>
+			<td>Module slug</td>
+		</tr>
+	</tbody>
+</table>
+#}}
+
+### reload\_module\_details($slug = '')
+
+Reload a modules details file and write changes to the database.
+
+<table cellpadding="0" cellspacing="0">
+	<tbody>
+		<tr>
+			<th width="100">Name</th>
+			<th width="100">Default</th>
+			<th width="100">Required</th>
+			<th>Description</th>
+		</tr>
+		<tr>
+			<td>slug</td>
+			<td></td>
+			<td>Yes</td>
+			<td>Module slug</td>
+		</tr>
+	</tbody>
+</table>

--- a/content/developers/tools/helpers/order.txt
+++ b/content/developers/tools/helpers/order.txt
@@ -1,0 +1,14 @@
+admin-theme-helper
+array-helper
+comments-helper
+date-helper
+debug-helper
+gravatar-helper
+html-helper | HTML Helper
+inflector-helper
+markdown-helper
+module-helper
+text-helper
+url-helper | URL Helper
+user-helper
+pagination-helper

--- a/content/developers/tools/helpers/pagination-helper.md
+++ b/content/developers/tools/helpers/pagination-helper.md
@@ -1,0 +1,44 @@
+# Pagination Helper
+
+Some helper functions to use with the [CodeIgniter Pagination Library](http://userguides.ellislab.com/codeigniter/libraries/pagination.html).
+
+## Functions
+
+### create\_pagination($uri, $total\_rows, $limit = null, $uri\_segment = 4)
+
+Helps you generate basic pagination. If you want something more flexible, use the actual [Pagination library](http://userguides.ellislab.com/codeigniter/libraries/pagination.html).
+
+<table cellpadding="0" cellspacing="0">
+	<tbody>
+		<tr>
+			<th width="100">Name</th>
+			<th width="130">Default</th>
+			<th width="100">Required</th>
+			<th>Description</th>
+		</tr>
+		<tr>
+			<td>uri</td>
+			<td></td>
+			<td>Yes</td>
+			<td>The URI to base pagination off.</td>
+		</tr>
+		<tr>
+			<td>total_rows</td>
+			<td></td>
+			<td>Yes</td>
+			<td>The total of the items to paginate.</td>
+		</tr>
+		<tr>
+			<td>limit</td>
+			<td>(Site Settings Records Per Page)</td>
+			<td>No</td>
+			<td>How many items to per page.</td>
+		</tr>
+		<tr>
+			<td>uri_segment</td>
+			<td>4</td>
+			<td>No</td>
+			<td>The URI Segment with the current page param</td>
+		</tr>
+	</tbody>
+</table>

--- a/content/developers/tools/helpers/text-helper.md
+++ b/content/developers/tools/helpers/text-helper.md
@@ -1,0 +1,70 @@
+# Text Helper
+
+This helper adds functionality not available in the [CodeIgniter Text Helper](http://codeigniter.com/user_guide/helpers/text_helper.html).
+
+## Functions
+
+### escape_tags($string)
+
+Replaces any `{` or `}` characters with HTML entities to prevent parsing.
+
+<table cellpadding="0" cellspacing="0">
+	<tbody>
+		<tr>
+			<th width="100">Name</th>
+			<th width="100">Default</th>
+			<th width="100">Required</th>
+			<th>Description</th>
+		</tr>
+		<tr>
+			<td>string</td>
+			<td></td>
+			<td>Yes</td>
+			<td>A string containing parser tags</td>
+		</tr>
+	</tbody>
+</table>
+
+	// usage
+	escape_tags('{{noparse}}Hello, my name is {{ name }}.{{/noparse}}');
+	
+	// output
+	'Hello, my name is &#123;&#123; name &#125;&#125;.'
+
+### process\_data\_jmr1($text = '')
+
+Minifies content by stripping out whitespace, etc. Used by the __Template__ library when minifying output is enabled.
+
+<table cellpadding="0" cellspacing="0">
+	<tbody>
+		<tr>
+			<th width="100">Name</th>
+			<th width="100">Default</th>
+			<th width="100">Required</th>
+			<th>Description</th>
+		</tr>
+		<tr>
+			<td>text</td>
+			<td></td>
+			<td>Yes</td>
+			<td>A string to minify. Most likely HTML code.</td>
+		</tr>
+	</tbody>
+</table>
+
+	// usage
+	$html = <<< HTML
+	<html>
+	<head>
+		<title>Page Title</title>
+	</head>
+	<body>
+		<p>This is the page content!</p>
+	</body>
+	</html>
+	HTML;
+	
+	$result = process_data_jmr1($html);
+	
+	// $result
+	'<html> <head> <title>Page Title</title> </head> <body> <p>This is the page content!</p> </body> </html>'

--- a/content/developers/tools/helpers/url-helper.md
+++ b/content/developers/tools/helpers/url-helper.md
@@ -1,0 +1,69 @@
+# URL Helper
+
+This helper adds functionality not available in the [CodeIgniter URL Helper](http://codeigniter.com/user_guide/helpers/url_helper.html).
+
+## Functions
+
+
+### url_title($str, $separator = 'dash', $lowercase = false)
+
+__&#42;&#42;Overrides default CodeIgniter function.&#42;&#42;__
+
+This behaves like the normal CodeIgniter `url_title()` function, except it adds Cyrillic alphabet support.
+
+<table cellpadding="0" cellspacing="0">
+	<tbody>
+		<tr>
+			<th width="100">Name</th>
+			<th width="100">Default</th>
+			<th width="100">Required</th>
+			<th>Description</th>
+		</tr>
+		<tr>
+			<td>str</td>
+			<td></td>
+			<td>Yes</td>
+			<td>The string to convert</td>
+		</tr>
+		<tr>
+			<td>separator</td>
+			<td>dash</td>
+			<td>No</td>
+			<td>Convert bad characters to this character</td>
+		</tr>
+		<tr>
+			<td>lowercase</td>
+			<td>false</td>
+			<td>No</td>
+			<td>Return result in lowercase?</td>
+		</tr>
+	</tbody>
+</table>
+
+
+### shorten_url($url = '')
+
+Takes a long URL and uses the TinyURL API to return a shortened version.
+
+<table cellpadding="0" cellspacing="0">
+	<tbody>
+		<tr>
+			<th width="100">Name</th>
+			<th width="100">Default</th>
+			<th width="100">Required</th>
+			<th>Description</th>
+		</tr>
+		<tr>
+			<td>url</td>
+			<td>(Current URL)</td>
+			<td>No</td>
+			<td>The long URL</td>
+		</tr>
+	</tbody>
+</table>
+
+	// usage
+	shorten_url('https://www.google.com/search?q=what+is+tinyurl');
+	
+	// returns
+	'http://tinyurl.com/cvwr4sn'

--- a/content/developers/tools/helpers/user-helper.md
+++ b/content/developers/tools/helpers/user-helper.md
@@ -1,0 +1,114 @@
+# User Helper
+
+A collection of helper functions included with the Users module.
+
+## Functions
+
+
+### is\_logged\_in()
+
+Checks if the user is logged in. Returns bool.
+
+
+### group\_has\_role($module, $role)
+
+Checks if the current users group has a specific role. Returns bool.
+
+<table cellpadding="0" cellspacing="0">
+	<tbody>
+		<tr>
+			<th width="100">Name</th>
+			<th width="100">Default</th>
+			<th width="100">Required</th>
+			<th>Description</th>
+		</tr>
+		<tr>
+			<td>module</td>
+			<td></td>
+			<td>Yes</td>
+			<td>Module slug</td>
+		</tr>
+		<tr>
+			<td>role</td>
+			<td></td>
+			<td>Yes</td>
+			<td>The role to test against</td>
+		</tr>
+	</tbody>
+</table>
+
+	// usage
+	group_has_role('pages', 'put_live');
+
+
+### role\_or\_die($module, $role, $redirect\_to = 'admin', $message = '')
+
+Tests if the current user has a specific role or redirects with a flashdata message.
+
+<table cellpadding="0" cellspacing="0">
+	<tbody>
+		<tr>
+			<th width="100">Name</th>
+			<th width="100">Default</th>
+			<th width="80">Required</th>
+			<th>Description</th>
+		</tr>
+		<tr>
+			<td>module</td>
+			<td></td>
+			<td>Yes</td>
+			<td>Module slug</td>
+		</tr>
+		<tr>
+			<td>role</td>
+			<td></td>
+			<td>Yes</td>
+			<td>The role to test against</td>
+		</tr>
+		<tr>
+			<td>redirect_to</td>
+			<td>admin</td>
+			<td>No</td>
+			<td>The URL to redirect to if no access</td>
+		</tr>
+		<tr>
+			<td>message</td>
+			<td><code>lang('cp_access_denied')</code></td>
+			<td>No</td>
+			<td>The flashdata message to display if no access</td>
+		</tr>
+	</tbody>
+</table>
+
+	// usage
+	role_or_die('pages', 'edit', 'admin/dashboard', 'Sorry, you can\'t edit pages.')
+
+
+### user_displayname($user, $linked = true)
+
+Return a users display name based on settings.
+
+<div class="tip"><strong>Note:</strong> If no <code>display_name</code> is set, this function will return the <code>username</code> instead.</div>
+
+<table cellpadding="0" cellspacing="0">
+	<tbody>
+		<tr>
+			<th width="100">Name</th>
+			<th width="100">Default</th>
+			<th width="100">Required</th>
+			<th>Description</th>
+		</tr>
+		<tr>
+			<td>user</td>
+			<td></td>
+			<td>Yes</td>
+			<td>The ID of the user</td>
+		</tr>
+		<tr>
+			<td>linked</td>
+			<td>true</td>
+			<td>No</td>
+			<td>Include a link to the users profile?</td>
+		</tr>
+	</tbody>
+</table>

--- a/content/developers/tools/index.md
+++ b/content/developers/tools/index.md
@@ -1,5 +1,5 @@
 # Tools
 
-PyroCMS has some handy built in tools (on top of the stock [CodeIgniter tools]()) to make developing with PyroCMS a little eaiser. They range from our own {{ link title="assets class" uri="developers/tools/assets" }} to the {{ link title="streams API" uri="developers/tools/streams-api" }}:
+PyroCMS has some handy built in tools (on top of the stock [CodeIgniter tools](http://codeigniter.com/user_guide/overview/features.html)) to make developing with PyroCMS a little easier. They range from our own {{ link title="assets class" uri="developers/tools/assets" }} to the {{ link title="streams API" uri="developers/tools/streams-api" }}:
 
 {{ nav:auto start="developers/tools" }}

--- a/content/developers/tools/order.txt
+++ b/content/developers/tools/order.txt
@@ -2,6 +2,7 @@ constants-and-globals | Constants and Globals
 assets
 events
 files
+helpers
 keywords
 pyrocache | PyroCache
 pyrofilter | PyroFilter


### PR DESCRIPTION
I've added documentation for all the various helpers that are added to PyroCMS and not documented in the CodeIgniter docs.

Before merging, please consider a few things:
- Do we want this to be under Tools > Helpers (like I have it now) or elsewhere?
- All of these helpers were taken from the 2.2 branch so as long as they exist in 2.1 as well, they can be copied over

There are a few methods I missed that either have bugs in them, or aren't being used anywhere so they are probably deprecated or orphaned.
