### PR TITLE
Updating the anchor naming to be more readable

### DIFF
--- a/system/fizl/helpers/MY_url_helper.php
+++ b/system/fizl/helpers/MY_url_helper.php
@@ -1,0 +1,66 @@
+<?php
+
+function anchor_format($string, $separator = 'dash', $lowercase = false) {
+	
+	$replace = ($separator == 'dash') ? '-' : '_';
+
+	$custom = array(
+		', [' => '[,', // optional params
+		', ]' => ']', // end optional params
+		', $' => ',', // remove $ from params and vars
+		', ' => $replace, // shrink up param space
+		'+' => 'and', // hope we meant 'and'
+		'array()' => 'array', // remove array parens
+		':' => $replace, // replace standalone colon
+		' = \'\'' => '', // remove blank params
+		' = \"\"' => '', // remove blank params
+		'/' => $replace, // for and/or
+		'. ' => $replace, // multi-sentence
+		'.' => '_', // filename support: index_php
+	);
+	
+	# safe characters
+	$safe = 'a-z0-9\-\._\(\):,\[\]\&'; // anchors can take more than normal chars
+	
+	// url_title() original
+	$trans = array(
+		'\s*=\s*'        => ':', // param values
+		'&\#\d+?;'       => '', // html digit entities; gets decoded
+		'&\S+?;'         => '', // html entities; gets decoded
+		'\s+'            => $replace, // multiple spaces
+		'[^'.$safe.']'   => '', // convert non-safe chars
+		$replace.'+'     => $replace, // multiple-replace to one
+		$replace.'$'     => '', // trim replace
+		'^'.$replace     => '', // trim replace
+		'\.+$'           => ''  // periods at end
+	);
+	
+	// convert our custom matches to safe characters first
+	$string = str_replace(array_keys($custom),array_values($custom),$string);
+	
+	// then convert everything else
+	foreach ($trans as $key => $val)
+	{
+		if (preg_match('#^&#i', $key))
+		{
+			// convert HTML entities back to crazy chars
+			if ( ! function_exists('_hed')) {
+				function _hed($matches) {
+					return html_entity_decode($matches[0]);
+				}
+			}
+			$string = preg_replace_callback("#".$key."#i", '_hed', $string);
+		}
+		else
+		{
+			$string = preg_replace("#".$key."#i", $val, $string);
+		}
+	}
+
+	if ($lowercase === true)
+	{
+		$string = strtolower($string);
+	}
+
+	return trim(stripslashes($string));
+}

--- a/system/fizl/plugins/format/libraries/format.php
+++ b/system/fizl/plugins/format/libraries/format.php
@@ -72,7 +72,7 @@ class Format extends Plugin {
 			// If there is more of the same, make the slug unique by adding the count
 			$make_unique = count($instances) > 1 ? '-'.count($instances) : '';
 
-			$slug = url_title($h->plaintext, 'dash', true).$make_unique;
+			$slug = anchor_format($h->plaintext.$make_unique, 'dash', true);
 			
 			// Add the slug to id to keep compatibility with docs plugin {{ docs:id_link title="Example" }}
 			$h->id = $slug;
@@ -81,9 +81,9 @@ class Format extends Plugin {
 			$link_top = $key > 0 ? '<a class="anchor-top hidden" href="'.current_url().'#top">&uarr;</a>' : '';
 
 			// Set the anchor link for all headings after the first
-			$link_anchor = $key > 0 ? '<a name="'.$slug.'"class="anchor hidden" href="'.current_url().'#'.$slug.'"></a>' : '';
+			$link_anchor = $key > 0 ? '<a name="'.$slug.'" class="anchor hidden" href="'.current_url().'#'.$slug.'"></a>' : '';
 			
-			// Add everythig together and overwrite the innertext property
+			// Add everything together and overwrite the innertext property
 			$h->innertext = $link_anchor.$h->innertext.$link_top;
 		
 		}


### PR DESCRIPTION
This will make the anchors more readable for everyone. Here are some
sample conversions it would make:

```
[OG] => Start/End Parameters
[new] => start-end-parameters

[OG] => assign_field($namespace, $stream_slug, $field_slug, $assign_data = array())
[new] => assign_field(namespace,stream_slug,field_slug,assign_data:array)

[OG] => teardown_assignment_field($assign_id, $force_delete = FALSE)
[new] => teardown_assignment_field(assign_id,force_delete:false)

[OG] => Adding and "locking" Fields
[new] => adding-and-locking-fields

[OG] => Upgrading to 2.0 from 1.x
[new] => upgrading-to-2_0-from-1_x

[OG] => Step 7: Upgrade your modules
[new] => step-7-upgrade-your-modules
```

Other than some characters changing, it keeps the same hovering and presentational functionality as before.
