### PR TITLE
Fixed default parameter value for WYSIWYG field type

### DIFF
--- a/content/developers/tools/streams-api/core-field-types.md
+++ b/content/developers/tools/streams-api/core-field-types.md
@@ -657,7 +657,7 @@ The WYSIWYG field creates a PyroCMS WYSIWYG text editor.
         
         <tr>
 		<td>editor_type</td>
-                <td>Advanced</td>
+                <td>simple</td>
 		<td>You can choose between a simple or advanced editor.</td>
 	</tr>
 </table>

--- a/content/field-types/wysiwyg.md
+++ b/content/field-types/wysiwyg.md
@@ -18,7 +18,7 @@ The WYSIWYG field type creates a PyroCMS WYSIWYG text editor.
 	<tbody> 
 		<tr> 
 			<td>Editor Type</td> 
-			<td>Advanced</td> 
+			<td>simple</td> 
 			<td>You can choose between a simple or advanced editor.</td> 
 		</tr> 
 </tbody> 


### PR DESCRIPTION
The default for "editor_type" was given as "Advanced" but it's actually "simple".
