### PR TITLE
Fix Issue #151

### DIFF
--- a/system/fizl/plugins/nav/libraries/nav.php
+++ b/system/fizl/plugins/nav/libraries/nav.php
@@ -159,7 +159,7 @@ class Nav extends Plugin {
 			}
 			else
 			{
-				$file = $order_string;
+				$file = trim($order_string);
 				$name = $this->guess_name($file);
 			}
 


### PR DESCRIPTION
This resolves an issue with parsing filenames found in order.txt files. Wraps each filename inside of trim() to resolve the issue.
