### PR TITLE
Added keyword filtering + Fixes

### DIFF
--- a/content/plugins/blog.md
+++ b/content/plugins/blog.md
@@ -39,6 +39,29 @@ In addition the following extra parameters are available:
 			<td>
 				Display posts from this category only.</td>
 		</tr>
+		
+		
+				<tr>
+			<td width="100">
+				keyword</td>
+			<td width="100">
+				Any Keyword</td>
+			<td width="100">
+				No</td>
+			<td>
+				Filters posts to show only this keyword.</td>
+		</tr>
+		
+		
+		<tr>
+			<td width="100">
+				additonal filtering</td>
+			<td colspan="3">
+		Everything in {{ link title="streams cycle" uri="plugins/streams/entry-looping#parameter-reference" }} except for <samp>stream</samp>, <samp>namespace</samp>, and <samp>where</samp>	
+				</td>
+		</tr>
+		
+		
 	</tbody>
 </table>
 


### PR DESCRIPTION
Added in a new feature, also seems like blog:posts could be a little more detailed. What do you think about just spelling the options out on this page? I'm just imagining the designer who doesn't want to know about streams "I just want a blog on the home page".
